### PR TITLE
Fixes default redirect value in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ module.
 
 ##### redirect
 
-Redirect to trailing "/" when the pathname is a dir. Defaults to `true`.
+Redirect to trailing "/" when the pathname is a dir. Defaults to `false`.
 
 ##### setHeaders
 


### PR DESCRIPTION
The README says the default value for the redirect option is `true`, but that does not seem to match the code at https://github.com/expressjs/serve-static/blob/master/index.js#L36 if I am reading this correctly.
