### PR TITLE
Avoid redirect loop if no index is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,17 @@ exports = module.exports = function serveStatic(root, options) {
     if (redirect) {
       // redirect relative to originalUrl
       stream.on('directory', function redirect() {
+        // make sure we don't create a redirect loop
+        if(originalUrl.pathname[originalUrl.pathname.length-1]==='/'){
+          // is root directory
+          if(originalUrl.pathname===path){
+            // accessing the root is forbidden
+            return stream.error(403)
+          }else{
+            // accessing a sub dir should be forwarded to next middleware
+            return stream.error(404)
+          }
+        }
         originalUrl.pathname += '/'
 
         var target = url.format(originalUrl)

--- a/test/test.js
+++ b/test/test.js
@@ -559,6 +559,28 @@ describe('serveStatic()', function(){
       });
     });
   });
+
+  describe('when index is set to false', function(){
+    var server;
+    before(function () {
+      server = createServer('test/fixtures/', {index:false}, function (req) {
+        req.originalUrl = req.url;
+        req.url = '/' + req.url.split('/').slice(2).join('/');
+      });
+    });
+
+    it('should not redirect if url points to root directory', function (done) {
+      request(server)
+        .get('/')
+        .expect(403, done);
+    });
+
+    it('should ignore urls that point to a subdirectory', function (done) {
+      request(server)
+        .get('/users/')
+        .expect(404, done);
+    });
+  });
 });
 
 function createServer(dir, opts, fn) {


### PR DESCRIPTION
**Problem**
The library falls into an infinite redirect loop when index option is set to false and the  url matches a directory.
**How to reproduce**
Serve a folder using serve static and disable index: `{index:false}` , try to access any subdirectory. You will get an infinite redirect.**Example**: `localhost/public/folder` will turn into `localhost/public/folder////////////////////`.

**Explanation**
When index option is set to false, the `send` library will, by default, send a 403 response if the requested resource is a directory. This will not happen if there are any `on('redirect',...)` listeners, as the `send` library will delegate to the listeners.

Unfortunately, the `serve-static` library handles the redirection but does not check to see if the resource ends with `/`. This results in the library redirecting to `originalUrl+='/'` over and over again. Producing an infinite redirect loop when index is set to false and the user requests a directory.

**Proposed Solution**
The problem has been fixed by assuming a desired behaviour similar to that of the `send` library and the rest of `serve-static`, i.e, 403 for root directory, and 404 (ignore and forward) for subdirectories, to ensure non-intrusiveness when using as a middleware.
2 passing tests have been added to the specs for both cases.
