### PR TITLE
Feat document link to etag through send

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ function serveStatic(root, options) {
       path = ''
     }
 
-    // create send stream
+    // create send stream (etag computation and other options are taken care of
+    // in this method)
     var stream = send(req, path, opts)
 
     // add directory handler


### PR DESCRIPTION
This explains the etag dependency link which is not directly present in the code of this module. It eases code browsing.