### PR TITLE
use 301 status code for directory redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function createRedirectDirectoryListener() {
     var res = this.res
 
     // send redirect response
-    res.statusCode = 303
+    res.statusCode = 301
     res.setHeader('Content-Type', 'text/html; charset=UTF-8')
     res.setHeader('Content-Length', Buffer.byteLength(msg))
     res.setHeader('X-Content-Type-Options', 'nosniff')

--- a/test/test.js
+++ b/test/test.js
@@ -227,7 +227,7 @@ describe('serveStatic()', function(){
         it('should redirect when directory without slash', function (done) {
           request(this.server)
           .get('/pets')
-          .expect(303, /Redirecting/, done)
+          .expect(301, /Redirecting/, done)
         })
       })
 
@@ -294,7 +294,7 @@ describe('serveStatic()', function(){
         it('should redirect when directory without slash', function (done) {
           request(this.server)
           .get('/pets')
-          .expect(303, /Redirecting/, done)
+          .expect(301, /Redirecting/, done)
         })
       })
 
@@ -377,28 +377,28 @@ describe('serveStatic()', function(){
       request(server)
       .get('/users')
       .expect('Location', '/users/')
-      .expect(303, done)
+      .expect(301, done)
     })
 
     it('should include HTML link', function(done){
       request(server)
       .get('/users')
       .expect('Location', '/users/')
-      .expect(303, /<a href="\/users\/">/, done)
+      .expect(301, /<a href="\/users\/">/, done)
     })
 
     it('should redirect directories with query string', function (done) {
       request(server)
       .get('/users?name=john')
       .expect('Location', '/users/?name=john')
-      .expect(303, done)
+      .expect(301, done)
     })
 
     it('should not redirect to protocol-relative locations', function (done) {
       request(server)
       .get('//users')
       .expect('Location', '/users/')
-      .expect(303, done)
+      .expect(301, done)
     })
 
     it('should not redirect incorrectly', function (done) {
@@ -456,7 +456,7 @@ describe('serveStatic()', function(){
       request(server)
       .get('/users')
       .expect(shouldNotHaveHeader('x-custom'))
-      .expect(303, done)
+      .expect(301, done)
     })
   })
 
@@ -591,7 +591,7 @@ describe('serveStatic()', function(){
       request(server)
       .get('/users')
       .expect('Location', '/users/')
-      .expect(303, done);
+      .expect(301, done);
     });
   });
 
@@ -608,14 +608,14 @@ describe('serveStatic()', function(){
       request(server)
       .get('/static/users')
       .expect('Location', '/static/users/')
-      .expect(303, done);
+      .expect(301, done);
     });
 
     it('should not choke on auth-looking URL', function(done){
       request(server)
       .get('//todo@txt')
       .expect('Location', '/todo@txt/')
-      .expect(303, done);
+      .expect(301, done);
     });
   });
 
@@ -662,7 +662,7 @@ describe('serveStatic()', function(){
       request(server)
       .get('/static/users')
       .expect('Location', '/static/users/')
-      .expect(303, done);
+      .expect(301, done);
     });
 
     it('should next() on mount point', function (done) {
@@ -675,7 +675,7 @@ describe('serveStatic()', function(){
       request(server)
       .get('/static')
       .expect('Location', '/static/')
-      .expect(303, done);
+      .expect(301, done);
     });
   });
 });


### PR DESCRIPTION
The 303 error code isn't really appropriate for this use case. It should be either a 301 (permanent) or a 302 (temporary). Using either 302 or 303 means that search engines won't pass along ranking to the target so it's lost. It also prevents caching of the redirect, which is done for 301. The cache can be invalidated by redirecting back from the target so it's harmless.