### PR TITLE
Make static-serve inherit the "etag" application setting when used with Express

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,8 @@ function serveStatic(root, options) {
   // copy options object
   var opts = Object.create(options || null)
 
+  var setEtagOption = (opts['etag'] !== undefined)
+
   // fall-though
   var fallthrough = opts.fallthrough !== false
 
@@ -69,6 +71,14 @@ function serveStatic(root, options) {
     : createNotFoundDirectoryListener()
 
   return function serveStatic(req, res, next) {
+    // If ETag was not set explicitly get up to date ETag setting from req.app if available
+    if(!setEtagOption && req.app && req.app.get && (typeof req.app.get === 'function')) {
+      var etag = req.app.get('etag')
+      if(etag !== undefined && (etag === true || etag === false)) {
+        opts['etag'] = etag
+      }
+    }
+
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       if (fallthrough) {
         return next()


### PR DESCRIPTION
From the Express 5.0 roadmap https://github.com/expressjs/express/issues/2237 and https://github.com/expressjs/express/issues/2317

If the etag setting is not explicitly set for serve-static and it is being used with Express, serve-static will inherit the etag setting from Express.

I have written tests for this PR and run them, but I have written them against the Express project rather than serve-static because the scenario requires both.  Tests look like this:

```js
it('should override static-serve etag setting if not set', function (done) {
      var fixtures = __dirname + '/fixtures';
      var app = express();

      app.disable('etag');
      app.use(express.static(fixtures));

      request(app)
      .get('/name.txt')
      .expect(function (res) {
        assert.ok(!('etag' in res.headers), 'should not have etag header')
      })
      .expect(200);

      app.set('etag', true)

      request(app)
      .get('/name.txt')
      .expect(function (res) {
        assert.ok(('etag' in res.headers), 'should have etag header')
      })
      .expect(200, done);
    })

    it('should not override static-serve etag setting if set', function (done) {
      var fixtures = __dirname + '/fixtures';
      var app = express();

      app.disable('etag');
      app.use(express.static(fixtures, {'etag' : true}));

      request(app)
      .get('/name.txt')
      .expect(function (res) {
        assert.ok(('etag' in res.headers), 'should not have etag header')
      })
      .expect(200);

      app.set('etag', true)

      request(app)
      .get('/name.txt')
      .expect(function (res) {
        assert.ok(('etag' in res.headers), 'should have etag header')
      })
      .expect(200, done);
    })

    it('should not override static-serve etag setting if disabled', function (done) {
      var fixtures = __dirname + '/fixtures';
      var app = express();

      app.disable('etag');
      app.use(express.static(fixtures, {'etag' : false}));

      request(app)
      .get('/name.txt')
      .expect(function (res) {
        assert.ok(!('etag' in res.headers), 'should not have etag header')
      })
      .expect(200);

      app.set('etag', true)

      request(app)
      .get('/name.txt')
      .expect(function (res) {
        assert.ok(!('etag' in res.headers), 'should have etag header')
      })
      .expect(200, done);
    })
```
