### PR TITLE
Support 'deny' and 'ignore' values for dotfiles option

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,18 @@ function serveStatic (root, options) {
       path = ''
     }
 
+    if (path.match(/^\/\./)) {
+      if (opts.dotfiles == "deny") {
+        var err = new Error();
+        err.status = 403;
+        return next(err)
+      } else if (opts.dotfiles == "ignore") {
+        var err = new Error();
+        err.status = 404;
+        return next(err)
+      }
+    }
+
     // create send stream
     var stream = send(req, path, opts)
 

--- a/index.js
+++ b/index.js
@@ -93,13 +93,13 @@ function serveStatic (root, options) {
     }
 
     if (path.match(/^\/\./)) {
-      if (opts.dotfiles == "deny") {
-        var err = new Error();
-        err.status = 403;
+      var err = new Error()
+
+      if (opts.dotfiles === 'deny') {
+        err.status = 403
         return next(err)
-      } else if (opts.dotfiles == "ignore") {
-        var err = new Error();
-        err.status = 404;
+      } else if (opts.dotfiles === 'ignore') {
+        err.status = 404
         return next(err)
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -385,14 +385,26 @@ describe('serveStatic()', function () {
 
   describe('hidden files', function () {
     var server
-    before(function () {
-      server = createServer(fixtures, {'dotfiles': 'allow'})
-    })
 
     it('should be served when dotfiles: "allow" is given', function (done) {
+      server = createServer(fixtures, {'dotfiles': 'allow'})
       request(server)
       .get('/.hidden')
       .expect(200, 'I am hidden', done)
+    })
+
+    it('should return 403 when dotfiles: "deny" is given', function (done) {
+      server = createServer(fixtures, {'dotfiles': 'deny'})
+      request(server)
+      .get('/.hidden')
+      .expect(403, done)
+    })
+
+    it('should return 404 when dotfiles: "ignore" is given', function (done) {
+      server = createServer(fixtures, {'dotfiles': 'ignore'})
+      request(server)
+      .get('/.hidden')
+      .expect(404, done)
     })
   })
 


### PR DESCRIPTION
I noticed these options are mentioned in the documentation but not actually implemented in the code or tests...