### PR TITLE
add prefixing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,19 +249,19 @@ var serveStatic = require('serve-static')
 
 var app = express()
 
-app.use(serveStatic( resolvePath( '/build', {
+app.use(serveStatic('/build', {
   prefix: rootByUserAgent
-}));
+}))
 
 app.listen(3000)
 
-function rootByUserAgent(req) {
-  var userAgent = req.get('user-agent');
+function rootByUserAgent (req) {
+  var userAgent = req.get('user-agent')
   // test user-agent for 'Internet Explorer'
-  if ((userAgent.match(/(MSIE)/i) || userAgent.match(/(Trident)/i)) && !userAgent.match(/(Edge)/i)) {
-    return '/build/compiled'
+  if (userAgent.match(/(MSIE)/i)) {
+    return '/compiled'
   }
-  return '/build/bundled';
+  return '/bundled'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ the arguments are:
   - `path` the file path that is being sent
   - `stat` the stat object of the file that is being sent
 
+##### prefix
+
+String or Function to set prefix for file serving. Default to ``
+
 ## Examples
 
 ### Serve files with vanilla node.js http server
@@ -232,6 +236,32 @@ function setCustomCacheControl (res, path) {
     // Custom Cache-Control for HTML files
     res.setHeader('Cache-Control', 'public, max-age=0')
   }
+}
+```
+
+#### Dynamic Prefixing
+
+This example shows how to set a dynamic prefix depending on the user agent.
+
+```js
+var express = require('express')
+var serveStatic = require('serve-static')
+
+var app = express()
+
+app.use(serveStatic( resolvePath( '/build', {
+  prefix: rootByUserAgent
+}));
+
+app.listen(3000)
+
+function rootByUserAgent(req) {
+  var userAgent = req.get('user-agent');
+  // test user-agent for 'Internet Explorer'
+  if ((userAgent.match(/(MSIE)/i) || userAgent.match(/(Trident)/i)) && !userAgent.match(/(Edge)/i)) {
+    return '/build/compiled'
+  }
+  return '/build/bundled';
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function serveStatic (root, options) {
   }
 
   // prefix options
-  var prefixPath = createPrefixFunction(opts.prefix || '');
+  var prefixPath = createPrefixFunction(opts.prefix || '')
 
   // setup options for send
   opts.maxage = opts.maxage || opts.maxAge || 0
@@ -215,11 +215,11 @@ function createRedirectDirectoryListener () {
  * Create a prefix function
  * @private
  */
-function createPrefixFunction(arg) {
+function createPrefixFunction (arg) {
   if (typeof arg === 'function') {
-    return arg;
+    return arg
   }
-  return function() {
-    return arg;
+  return function () {
+    return arg
   }
 }

--- a/index.js
+++ b/index.js
@@ -60,6 +60,9 @@ function serveStatic (root, options) {
     throw new TypeError('option setHeaders must be function')
   }
 
+  // prefix options
+  var prefixPath = createPrefixFunction(opts.prefix || '');
+
   // setup options for send
   opts.maxage = opts.maxage || opts.maxAge || 0
   opts.root = resolve(root)
@@ -85,7 +88,7 @@ function serveStatic (root, options) {
 
     var forwardError = !fallthrough
     var originalUrl = parseUrl.original(req)
-    var path = parseUrl(req).pathname
+    var path = prefixPath(req) + parseUrl(req).pathname
 
     // make sure redirect occurs at mount
     if (path === '/' && originalUrl.pathname.substr(-1) !== '/') {
@@ -205,5 +208,18 @@ function createRedirectDirectoryListener () {
     res.setHeader('X-Content-Type-Options', 'nosniff')
     res.setHeader('Location', loc)
     res.end(doc)
+  }
+}
+
+/**
+ * Create a prefix function
+ * @private
+ */
+function createPrefixFunction(arg) {
+  if (typeof arg === 'function') {
+    return arg;
+  }
+  return function() {
+    return arg;
   }
 }


### PR DESCRIPTION
Adding support for a prefix function in options to dynamically prefixing the paths. This could be usefull to serve different subfolders statically depeneding on the user-agent or other parts of the request.
For example:

```js
var express = require('express')
var serveStatic = require('serve-static')

var app = express()

app.use(serveStatic( resolvePath( '/build', {
  prefix: serveByUserAgent
}));

app.listen(3000)

function serveByUserAgent(req) {
  var userAgent = req.get('user-agent');
  // test user-agent for 'Internet Explorer'
  if ((userAgent.match(/(MSIE)/i) || userAgent.match(/(Trident)/i)) && !userAgent.match(/(Edge)/i)) {
    return '/compiled'
  }
  return '/bundled';
}
```