### PR TITLE
proposal: add static cache

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,76 @@
+const EventEmitter = require('events')
+const cp = require('child_process')
+const path = require('path')
+
+const targets = [
+  path.resolve(__dirname, 'targets/simple.js'),
+  path.resolve(__dirname, 'targets/static-cache.js')
+]
+
+class AutocannonBench extends EventEmitter {
+  constructor (options) {
+    super(options)
+    this.options = options || {}
+  }
+
+  run (options) {
+    const exectuable = path.resolve(__dirname, '../node_modules/autocannon/autocannon.js')
+
+    const args = [
+      '-d',
+      this.options.duration || options.duration, // sec
+      '-c',
+      this.options.connections || options.connections,
+      // '-j',
+      // '-n',
+      `http://127.0.0.1:${this.options.port || options.port}${this.options.path || options.path || ''}`
+    ]
+
+    return cp.spawnSync(exectuable, args, { stdio: 'inherit' })
+  }
+}
+
+function runBench (target, cb) {
+  let hasCalled = false
+
+  const bench = new AutocannonBench()
+  const child = cp.spawn(process.argv[0], [target], { stdio: [0, 1, 2, 'ipc'] })
+
+  child.on('message', (msg) => {
+    if (msg === 'ready') {
+      bench.run({ duration: 100, connections: 10, port: 3000 })
+      child.kill()
+    }
+  })
+
+  child.on('error', (err) => {
+    if (hasCalled) return
+    hasCalled = true
+
+    cb(err)
+  })
+
+  child.on('close', () => {
+    if (hasCalled) return
+    hasCalled = true
+
+    cb(null)
+  })
+}
+
+function run (targets, index = 0) {
+  console.log('Running benchmark:')
+  console.log(targets[index])
+  console.log('\n')
+
+  runBench(targets[index], (err) => {
+    if (err) throw err
+
+    if (++index >= targets.length) return
+
+    console.log('\n')
+    run(targets, index)
+  })
+}
+
+run(targets)

--- a/benchmark/targets/fixtures/index.html
+++ b/benchmark/targets/fixtures/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="css/style.css" rel="stylesheet">
+  </head>
+  <body>
+    A webpage
+  </body>
+</html>

--- a/benchmark/targets/simple.js
+++ b/benchmark/targets/simple.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const path = require('path')
+const serveStatic = require('../../')
+
+const app = express()
+
+app.use(serveStatic(path.join(__dirname, 'fixtures')))
+
+app.listen(3000, () => {
+  process.send('ready')
+})

--- a/benchmark/targets/static-cache.js
+++ b/benchmark/targets/static-cache.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const path = require('path')
+const serveStatic = require('../../')
+
+const app = express()
+
+app.use(serveStatic(path.join(__dirname, 'fixtures'), {staticCache: true}))
+
+app.listen(3000, () => {
+  process.send('ready')
+})

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "send": "0.15.6"
   },
   "devDependencies": {
+    "autocannon": "^0.16.5",
     "eslint": "3.19.0",
     "eslint-config-standard": "10.2.1",
     "eslint-plugin-import": "2.7.0",
@@ -19,6 +20,7 @@
     "eslint-plugin-node": "5.1.1",
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-standard": "3.0.1",
+    "express": "^4.15.4",
     "istanbul": "0.4.5",
     "mocha": "2.5.3",
     "supertest": "1.1.0"


### PR DESCRIPTION
This is WIP since it's a code proposal.

This intends to get rid of the arguments "do not use Node for static file serving", as software like Nginx does cached reading itself, in order to not call the FS. I suggest having this because it's a very simple yet powerful addition. 

This needs some more checking in the code and obviously tests. 


da4b549 adds benchmarks
0d34b27 is the implementation

cc @dougwilson 

this is also a prelude to my comment here https://github.com/expressjs/serve-static/issues/62#issuecomment-325443953

See a simple, yet not averaged out benchmark here.

<img width="511" alt="hyper" src="https://user-images.githubusercontent.com/3899684/30774973-f26f8626-a08a-11e7-89cf-08ce06711359.png">

