### PR TITLE
Prevents webpack crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function serveStatic (root, options) {
         return
       }
 
-      next()
+      next && next()
     })
 
     // pipe


### PR DESCRIPTION
If there's not robots.txt file, webpack using this dependency will crash in node <=8