### PR TITLE
Allow calling next on finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,10 +124,10 @@ function serveStatic (root, options) {
     })
     
     if(callNextOnFinish){
-      res.once('finish', ()=>{
+      res.once('finish', function () {
         next();
       })
-      res.once('close', ()=>{
+      res.once('close', function() {
         if(!res.writableEnded){
           next(new Error('Did not finish sending data (client my have aborted mid request)'))
         }


### PR DESCRIPTION
Pull Request for https://github.com/expressjs/serve-static/issues/136#issuecomment-661186897. Not married to this, but showing a rough outline of what I'm asking for. Defaults to the current behavior of ending the request cycle if sending the file is successful. Allows post-processing the request.

Still figuring out the right way to add a test that:
1) starts a request
2) makes the server sleep for 5 seconds (approximate a long database query)
3) the client times out/aborts the request
4) The server still calls the next middleware

My use case involves puppeteer and making server.close wait until after 4). But it looks like you have pure unit tests here so it might be more setup than you want.

Note on-finished isn't good enough because the "finish" event isn't fired if "close" is fired first (the client aborts the request). And I'm assuming people would want to know if the file didn't completely send.
