### PR TITLE
Considers forwarded prefix header when redirecting directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,12 +186,15 @@ function createRedirectDirectoryListener () {
       return
     }
 
+    // get prefix if forwarded by proxy
+    var forwardedPrefix = this.req.headers['x-forwarded-prefix'] || ''
+
     // get original URL
     var originalUrl = parseUrl.original(this.req)
 
     // append trailing slash
     originalUrl.path = null
-    originalUrl.pathname = collapseLeadingSlashes(originalUrl.pathname + '/')
+    originalUrl.pathname = forwardedPrefix + collapseLeadingSlashes(originalUrl.pathname + '/')
 
     // reformat the URL
     var loc = encodeUrl(url.format(originalUrl))

--- a/test/test.js
+++ b/test/test.js
@@ -521,6 +521,23 @@ describe('serveStatic()', function () {
         .expect(404, done)
     })
 
+    describe('when redirected with x-forwarded-prefix', function () {
+      var server
+      before(function () {
+        server = createServer(fixtures, null, function (req, res) {
+          req.url = req.url.replace(/\/snow(\/|$)/, '/snow \u2603$1')
+          req.headers['x-forwarded-prefix'] = '/prefix'
+        })
+      })
+
+      it('should redirect directories appending prefix', function (done) {
+        request(server)
+          .get('/users')
+          .expect('Location', '/prefix/users/')
+          .expect(301, done)
+      })
+    })
+
     describe('when false', function () {
       var server
       before(function () {


### PR DESCRIPTION
If express is behind a proxy that strips the path prefix before forwarding the request, the current redirection will lead to errors. In order to fix that, it should consider and prepend the prefix if it exists. 

As an example, [here is a related issue](https://github.com/scottie1984/swagger-ui-express/issues/183).

Also, just for reference on the "X-Forwarded-Prefix" header, I'll share some links:
* https://docs.humio.com/docs/installation/cluster/nginx-reverse-proxy/
* https://doc.traefik.io/traefik/middlewares/stripprefix/
