### PR TITLE
refactor: zeroPad to use padStart for improved readability

### DIFF
--- a/scripts/version-history.js
+++ b/scripts/version-history.js
@@ -53,11 +53,5 @@ function repeat (str, length) {
 }
 
 function zeroPad (number, length) {
-  var num = number.toString()
-
-  while (num.length < length) {
-    num = '0' + num
-  }
-
-  return num
+  return number.toString().padStart(length, '0')
 }


### PR DESCRIPTION
Replaced the manual loop with `padStart` to simplify the code and improve readability. This aligns with modern JavaScript practices, making the function more concise and easier to maintain. No functional changesjust a cleaner, more efficient approach to padding numbers with leading zeros.