### PR TITLE
Refactor collapseLeadingSlashes function for simplicity and readability

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,16 +129,9 @@ function serveStatic (root, options) {
  * Collapse all leading slashes into a single slash
  * @private
  */
-function collapseLeadingSlashes (str) {
-  for (var i = 0; i < str.length; i++) {
-    if (str.charCodeAt(i) !== 0x2f /* / */) {
-      break
-    }
-  }
 
-  return i > 1
-    ? '/' + str.substr(i)
-    : str
+function collapseLeadingSlashes(str) {
+  return str.replace(/^\/+/, '/') || '/';
 }
 
 /**


### PR DESCRIPTION
Replaced the old implementation of collapseLeadingSlashes, which iterated over each character, with a more concise and efficient version using a regular expression. The new version uses 
eplace() to collapse leading slashes into a single slash and handles empty strings by returning '/'. This update improves code readability and leverages modern JavaScript string methods.