### PR TITLE
Set even more strict CSP header in redirect response

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function createRedirectDirectoryListener () {
     res.statusCode = 301
     res.setHeader('Content-Type', 'text/html; charset=UTF-8')
     res.setHeader('Content-Length', Buffer.byteLength(doc))
-    res.setHeader('Content-Security-Policy', "default-src 'none'")
+    res.setHeader('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'; form-action 'none'")
     res.setHeader('X-Content-Type-Options', 'nosniff')
     res.setHeader('Location', loc)
     res.end(doc)

--- a/test/test.js
+++ b/test/test.js
@@ -511,7 +511,7 @@ describe('serveStatic()', function () {
     it('should respond with default Content-Security-Policy', function (done) {
       request(server)
         .get('/users')
-        .expect('Content-Security-Policy', "default-src 'none'")
+        .expect('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'; form-action 'none'")
         .expect(301, done)
     })
 


### PR DESCRIPTION
suggested fix for the too broad (wildcard) CSP directives (`frame-ancestors` and `form-action`) in redirect response.

fixes #187