### PR TITLE
conditionally set headers (if not already set) in redirect response

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,6 +207,11 @@ function createRedirectDirectoryListener () {
   }
 }
 
+/**
+ * Set default value for the header only if it is not already set in the response
+ * @private
+ */
+
 function setHeaderIfNotSet (res, name, value) {
   if (!res.hasHeader(name)) {
     res.setHeader(name, value)

--- a/index.js
+++ b/index.js
@@ -198,11 +198,17 @@ function createRedirectDirectoryListener () {
 
     // send redirect response
     res.statusCode = 301
-    res.setHeader('Content-Type', 'text/html; charset=UTF-8')
-    res.setHeader('Content-Length', Buffer.byteLength(doc))
-    res.setHeader('Content-Security-Policy', "default-src 'none'")
-    res.setHeader('X-Content-Type-Options', 'nosniff')
-    res.setHeader('Location', loc)
+    setHeaderIfNotSet(res, 'Content-Type', 'text/html; charset=UTF-8')
+    setHeaderIfNotSet(res, 'Content-Length', Buffer.byteLength(doc))
+    setHeaderIfNotSet(res, 'Content-Security-Policy', "default-src 'none'")
+    setHeaderIfNotSet(res, 'X-Content-Type-Options', 'nosniff')
+    setHeaderIfNotSet(res, 'Location', loc)
     res.end(doc)
+  }
+}
+
+function setHeaderIfNotSet (res, name, value) {
+  if (!res.hasHeader(name)) {
+    res.setHeader(name, value)
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -469,6 +469,9 @@ describe('serveStatic()', function () {
     before(function () {
       server = createServer(fixtures, null, function (req, res) {
         req.url = req.url.replace(/\/snow(\/|$)/, '/snow \u2603$1')
+        if (req.url.match(/\/pets/)) {
+          res.setHeader('Content-Security-Policy', "default-src 'self'")
+        }
       })
     })
 
@@ -508,10 +511,17 @@ describe('serveStatic()', function () {
         .expect(301, />Redirecting to \/snow%20%E2%98%83\/</, done)
     })
 
-    it('should respond with default Content-Security-Policy', function (done) {
+    it('should respond with default Content-Security-Policy when header is not set', function (done) {
       request(server)
         .get('/users')
         .expect('Content-Security-Policy', "default-src 'none'")
+        .expect(301, done)
+    })
+
+    it('should respond with custom Content-Security-Policy when header is set', function (done) {
+      request(server)
+        .get('/pets')
+        .expect('Content-Security-Policy', "default-src 'self'")
         .expect(301, done)
     })
 


### PR DESCRIPTION
suggested fix for possibility to override default headers in redirect response.

fixes https://github.com/expressjs/serve-static/issues/187