### PR TITLE
chore(deps): remove devDependency `safe-buffer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-standard": "4.1.0",
     "mocha": "^10.7.0",
     "nyc": "^17.0.0",
-    "safe-buffer": "^5.2.1",
     "supertest": "^6.3.4"
   },
   "files": [

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 
 var assert = require('assert')
-var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var path = require('path')
 var request = require('supertest')


### PR DESCRIPTION
This PR removes the `safe-buffer` package from devDependencies as it's no longer needed. Since we no longer support Node.js versions older than 18.0.0, the native Buffer class now fully handles security concerns. Additionally, there are no instances of `new Buffer(...)` usage in the repository.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->