### PR TITLE
docs: retroactively note 2.0.0-beta.1 api change in history file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
   * Change `dotfiles` option default to `'ignore'`
   * Drop support for Node.js 0.8
   * Remove `hidden` option; use `dotfiles` option instead
+  * Remove `mime` export; use `mime-types` package instead
   * deps: send@1.0.0-beta.1
     - Use `mime-types` for file to content type mapping
     - deps: debug@3.1.0


### PR DESCRIPTION
The removed export was not explicitly called out in `History.md`. As it is a breaking API change, this PR retrofits the history file to document it.

Note, the [release notes for the beta](https://github.com/expressjs/serve-static/releases/tag/v2.0.0-beta.1) mirror this section of `History.md`. I don't have permission to edit those but a maintainer could if it's important to have consistency.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->