### PR TITLE
Revert "feat: conditionally set headers (if not already set) in redirect response (#190)"

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,22 +198,11 @@ function createRedirectDirectoryListener () {
 
     // send redirect response
     res.statusCode = 301
-    setHeaderIfNotSet(res, 'Content-Type', 'text/html; charset=UTF-8')
-    setHeaderIfNotSet(res, 'Content-Length', Buffer.byteLength(doc))
-    setHeaderIfNotSet(res, 'Content-Security-Policy', "default-src 'none'")
-    setHeaderIfNotSet(res, 'X-Content-Type-Options', 'nosniff')
-    setHeaderIfNotSet(res, 'Location', loc)
+    res.setHeader('Content-Type', 'text/html; charset=UTF-8')
+    res.setHeader('Content-Length', Buffer.byteLength(doc))
+    res.setHeader('Content-Security-Policy', "default-src 'none'")
+    res.setHeader('X-Content-Type-Options', 'nosniff')
+    res.setHeader('Location', loc)
     res.end(doc)
-  }
-}
-
-/**
- * Set default value for the header only if it is not already set in the response
- * @private
- */
-
-function setHeaderIfNotSet (res, name, value) {
-  if (!res.hasHeader(name)) {
-    res.setHeader(name, value)
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -468,9 +468,6 @@ describe('serveStatic()', function () {
     before(function () {
       server = createServer(fixtures, null, function (req, res) {
         req.url = req.url.replace(/\/snow(\/|$)/, '/snow \u2603$1')
-        if (req.url.match(/\/pets/)) {
-          res.setHeader('Content-Security-Policy', "default-src 'self'")
-        }
       })
     })
 
@@ -510,17 +507,10 @@ describe('serveStatic()', function () {
         .expect(301, />Redirecting to \/snow%20%E2%98%83\/</, done)
     })
 
-    it('should respond with default Content-Security-Policy when header is not set', function (done) {
+    it('should respond with default Content-Security-Policy', function (done) {
       request(server)
         .get('/users')
         .expect('Content-Security-Policy', "default-src 'none'")
-        .expect(301, done)
-    })
-
-    it('should respond with custom Content-Security-Policy when header is set', function (done) {
-      request(server)
-        .get('/pets')
-        .expect('Content-Security-Policy', "default-src 'self'")
         .expect(301, done)
     })
 


### PR DESCRIPTION
This reverts commit b51ab84ce105252909ae07e5a3c215352f2e0e6e

Ref: https://github.com/expressjs/serve-static/pull/197#discussion_r2015247536

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
