### PR TITLE
ci: add node.js 24 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # Node.js release schedule: https://nodejs.org/en/about/releases/
-        node-version: [18, 19, 20, 21, 22, 23]
+        node-version: [18, 19, 20, 21, 22, 23, 24]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
This PR adds [Node.js v24](https://github.com/nodejs/node/releases/tag/v24.0.0) to the test matrix.