### PR TITLE
feat: add typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,114 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { HttpError } from 'http-errors'
+
+/**
+ * Create a new middleware function to serve files from within a given root directory.
+ * The file to serve will be determined by combining req.url with the provided root directory.
+ * When a file is not found, instead of sending a 404 response, this module will instead call next() to move on to the next middleware, allowing for stacking and fall-backs.
+ */
+declare function serveStatic<R extends ServerResponse>(
+  root: string,
+  options?: ServeStaticOptions<R>,
+): RequestHandler<R>
+
+export interface ServeStaticOptions<R extends ServerResponse = ServerResponse> {
+  /**
+   * Enable or disable accepting ranged requests, defaults to true.
+   * Disabling this will not send Accept-Ranges and ignore the contents of the Range request header.
+   */
+  acceptRanges?: boolean
+
+  /**
+   * Enable or disable setting Cache-Control response header, defaults to true.
+   * Disabling this will ignore the immutable and maxAge options.
+   */
+  cacheControl?: boolean
+
+  /**
+   * Set how 'dotfiles' are treated when encountered. A dotfile is a file or directory that begins with a dot ('.').
+   * Note this check is done on the path itself without checking if the path actually exists on the disk.
+   * If root is specified, only the dotfiles above the root are checked (i.e. the root itself can be within a dotfile when when set to 'deny').
+   * The default value is 'ignore'.
+   * 'allow' No special treatment for dotfiles
+   * 'deny' Send a 403 for any request for a dotfile
+   * 'ignore' Pretend like the dotfile does not exist and call next()
+   */
+  dotfiles?: string
+
+  /**
+   * Enable or disable etag generation, defaults to true.
+   */
+  etag?: boolean
+
+  /**
+   * Set file extension fallbacks. When set, if a file is not found, the given extensions will be added to the file name and search for.
+   * The first that exists will be served. Example: ['html', 'htm'].
+   * The default value is false.
+   */
+  extensions?: string[] | false
+
+  /**
+   * Set the middleware to have client errors fall-through as just unhandled requests,
+   * otherwise forward a client error.
+   * The difference is that client errors like a bad request or a request to a non-existent file
+   * will cause this middleware to simply next() to your next middleware when this value is true.
+   * When this value is false, these errors (even 404s), will invoke next(err).
+   *
+   * Typically true is desired such that multiple physical directories can be mapped to the same web address
+   * or for routes to fill in non-existent files.
+   *
+   * The value false can be used if this middleware is mounted at a path that is designed to be strictly
+   * a single file system directory, which allows for short-circuiting 404s for less overhead.
+   * This middleware will also reply to all methods.
+   *
+   * The default value is true.
+   */
+  fallthrough?: boolean
+
+  /**
+   * Enable or disable the immutable directive in the Cache-Control response header.
+   * If enabled, the maxAge option should also be specified to enable caching. The immutable directive will prevent supported clients from making conditional requests during the life of the maxAge option to check if the file has changed.
+   */
+  immutable?: boolean
+
+  /**
+   * By default this module will send 'index.html' files in response to a request on a directory.
+   * To disable this set false or to supply a new index pass a string or an array in preferred order.
+   */
+  index?: boolean | string | string[]
+
+  /**
+   * Enable or disable Last-Modified header, defaults to true. Uses the file system's last modified value.
+   */
+  lastModified?: boolean
+
+  /**
+   * Provide a max-age in milliseconds for http caching, defaults to 0. This can also be a string accepted by the ms module.
+   */
+  maxAge?: number | string
+
+  /**
+   * Redirect to trailing '/' when the pathname is a dir. Defaults to true.
+   */
+  redirect?: boolean
+
+  /**
+   * Function to set custom headers on response. Alterations to the headers need to occur synchronously.
+   * The function is called as fn(res, path, stat), where the arguments are:
+   * res the response object
+   * path the file path that is being sent
+   * stat the stat object of the file that is being sent
+   */
+  setHeaders?: ((res: R, path: string, stat: any) => any)
+}
+
+export interface RequestHandler<R extends ServerResponse> {
+  (request: IncomingMessage, response: R, next: (err?: HttpError) => void): any
+}
+
+export interface RequestHandlerConstructor<R extends ServerResponse> {
+  (root: string, options?: ServeStaticOptions<R>): RequestHandler<R>
+}
+
+
+export default serveStatic

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "send": "^1.2.0"
   },
   "devDependencies": {
+    "@types/node": "18.19.130",
     "eslint": "7.32.0",
     "eslint-config-standard": "14.1.1",
     "eslint-plugin-import": "2.32.0",
@@ -29,7 +30,8 @@
   },
   "files": [
     "LICENSE",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
Adds typescript type definitions

Adapted from [`@types/serve-static`](https://npmx.dev/package-code/@types/serve-static/v/2.2.0/index.d.ts)

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
